### PR TITLE
Empty Surgery Kit

### DIFF
--- a/code/game/objects/items/stacks/civ_recipes.dm
+++ b/code/game/objects/items/stacks/civ_recipes.dm
@@ -674,6 +674,9 @@
 			new/datum/stack_recipe("blue bedsheet", /obj/item/weapon/bedsheet/blue, 2, _time = 75, _one_per_turf = FALSE, _on_floor = TRUE),
 			new/datum/stack_recipe("yellow bedsheet", /obj/item/weapon/bedsheet/blue, 2, _time = 75, _one_per_turf = FALSE, _on_floor = TRUE),
 			new/datum/stack_recipe("red bedsheet", /obj/item/weapon/bedsheet/red, 2, _time = 75, _one_per_turf = FALSE, _on_floor = TRUE),))
+			
+	if (current_res[1] >= 18 && current_res[3]>= 26) // Same level that bronze surgical tools can be made.
+		recipes += list(new/datum/stack_recipe("surgery kit", /obj/item/weapon/storage/firstaid/surgery_empty, 6, _time = 90, _one_per_turf = FALSE, _on_floor = TRUE))
 
 
 /material/gold/generate_recipes_civs(var/list/current_res = list(0,0,0))

--- a/code/game/objects/items/weapons/storage/medkit.dm
+++ b/code/game/objects/items/weapons/storage/medkit.dm
@@ -82,5 +82,14 @@
 	new /obj/item/weapon/surgery/retractor(src)
 	new /obj/item/weapon/surgery/scalpel(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	
+/obj/item/weapon/storage/firstaid/surgery_empty
+	name = "surgery kit"
+	desc = "Contains tools for surgery."
+	icon_state = "firstaid2"
+	item_state = "firstaid_2"
+	storage_slots = 7
+	max_w_class = 3
+	max_storage_space = 28
 
 	make_exact_fit()


### PR DESCRIPTION
Adds a craftable empty surgery kit to the Civilizations gamemode.
Requires 6 cloth, and should become available at the same research levels as the bronze surgical tools.
I probably messed something up, and most certainly could've done better coding it, but I did test it out a little and it seems to be working.