### PR TITLE
buff stone fortificantions health and stone wall health

### DIFF
--- a/code/game/objects/covers.dm
+++ b/code/game/objects/covers.dm
@@ -281,7 +281,7 @@
 	opacity = TRUE
 	amount = 0
 	layer = 3
-	health = 300
+	health = 600
 	wood = FALSE
 	wall = TRUE
 	flammable = FALSE

--- a/code/game/objects/structures/barricades.dm
+++ b/code/game/objects/structures/barricades.dm
@@ -278,8 +278,8 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "stone_brick"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/stone_v
@@ -288,8 +288,8 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "stone_brick2"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/stone_h/crenelated
@@ -298,8 +298,8 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "stone_brick_c"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/stone_v/crenelated
@@ -308,36 +308,36 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "stone_brick_c2"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/stone_h/New()
 	..()
 	icon_state = "stone_brick"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 /obj/structure/barricade/stone_v/New()
 	..()
 	icon_state = "stone_brick2"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/stone_h/crenelated/New()
 	..()
 	icon_state = "stone_brick_c"
 	name = "crenelated stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/stone_v/crenelated/New()
 	..()
 	icon_state = "stone_brick_c2"
 	name = "crenelated stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/stone_h/ex_act(severity)
 	switch(severity)
@@ -398,16 +398,16 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "jap_wall_h"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/jap_h/New()
 	..()
 	icon_state = "jap_wall_h"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/jap_h/ex_act(severity)
 	switch(severity)
@@ -428,16 +428,16 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "jap_wall_h_l"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/jap_h_l/New()
 	..()
 	icon_state = "jap_wall_h_l"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/jap_h_l/ex_act(severity)
 	switch(severity)
@@ -458,16 +458,16 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "jap_wall_h_r"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/jap_h_r/New()
 	..()
 	icon_state = "jap_wall_h_r"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/jap_h_r/ex_act(severity)
 	switch(severity)
@@ -488,16 +488,16 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "jap_wall_v"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/jap_v/New()
 	..()
 	icon_state = "jap_wall_v"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/jap_v/ex_act(severity)
 	switch(severity)
@@ -518,16 +518,16 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "jap_wall_v_t"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/jap_v_t/New()
 	..()
 	icon_state = "jap_wall_v_t"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/jap_v_t/ex_act(severity)
 	switch(severity)
@@ -548,16 +548,16 @@
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "jap_wall_v_b"
 	material = "stone"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 	material_name = "stone"
 
 /obj/structure/barricade/jap_v_b/New()
 	..()
 	icon_state = "jap_wall_v_b"
 	name = "stone wall"
-	health = 600
-	maxhealth = 600
+	health = 2709
+	maxhealth = 2709
 
 /obj/structure/barricade/jap_v_b/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
balance: increased health in stone fortifications by near 350%, for comparison, with a steel katana you can destroy a stone fortification in 14 seconds, with changes its 60 seconds now

obs: you can use ladders to climb those

balance: doubled stone walls health, for comparison using a steel katana you can destroy it in 35 seconds, now it is 70 seconds

didnt buffed iron doors here because doors code makes no sense for me, tas pls