### PR TITLE
Fixing Dollar initialization on money.dm

### DIFF
--- a/code/game/objects/items/stacks/money.dm
+++ b/code/game/objects/items/stacks/money.dm
@@ -32,7 +32,7 @@
 		singular_name = "Dollar Bill"
 		icon_state = "money"
 		amount = 50
-		value = 4
+		value = 1
 		return ..()
 	else if (map.ordinal_age == 0)
 		name = "spanish reales"

--- a/code/game/objects/items/stacks/money.dm
+++ b/code/game/objects/items/stacks/money.dm
@@ -1,4 +1,4 @@
-//spanish money was the world currency in the early 18th century. 1 doubloon = 2 escudos = 4 dollars = 32 reales
+//spanish money was the world currency in the early 18th century. 1 doubloon = 2 escudos = 4 spanish dollars = 32 reales
 
 /obj/item/stack/money
 	name = "gold coins"
@@ -26,14 +26,22 @@
 	amount = 50
 	value = 1
 /obj/item/stack/money/real/New()
-	..()
-	if (map.ordinal_age == 0)
+	if (map.ordinal_age >= 4)
+		name = "Dollar Bills"
+		desc = "A/some dollar(s) of paper money."
+		singular_name = "Dollar Bill"
+		icon_state = "money"
+		amount = 50
+		value = 4
+		return ..()
+	else if (map.ordinal_age == 0)
 		name = "spanish reales"
 		desc = "A small silver coin."
 		singular_name = "real"
 		icon_state = "silvercoin_pile"
-		amount = 1
+		amount = 50
 		value = 1
+		return ..()
 
 /obj/item/stack/money/dollar
 	name = "spanish dollars"
@@ -43,14 +51,22 @@
 	amount = 1
 	value = 8
 /obj/item/stack/money/dollar/New()
-	..()
-	if (map.ordinal_age == 0)
+	if (map.ordinal_age >= 4)
+		name = "5 Dollar Bills"
+		desc = "A/some dollar(s) of paper money."
+		singular_name = "5 Dollar Bill"
+		icon_state = "money"
+		amount = 1
+		value = 8
+		return ..()
+	else if (map.ordinal_age == 0)
 		name = "spanish dollars"
 		desc = "A silver coin, also called piece of eight, worth 8 reales."
 		singular_name = "dollar"
 		icon_state = "silvercoin_pile"
 		amount = 1
 		value = 8
+		return ..()
 
 /obj/item/stack/money/escudo
 	name = "spanish escudos"
@@ -59,15 +75,23 @@
 	icon_state = "goldcoin_pile"
 	amount = 1
 	value = 16
-/obj/item/stack/money/escudo/dollar/New()
-	..()
-	if (map.ordinal_age == 0)
+/obj/item/stack/money/escudo/New()
+	if (map.ordinal_age >= 4) //Not being called
+		name = "20 Dollar Bills"
+		desc = "A/some dollar(s) of paper money."
+		singular_name = "20 Dollar Bill"
+		icon_state = "money"
+		amount = 1
+		value = 16
+		return ..()
+	else if (map.ordinal_age == 0)
 		name = "spanish escudos"
 		desc = "A gold coin. Worth 16 reales."
 		singular_name = "escudo"
 		icon_state = "goldcoin_pile"
 		amount = 1
 		value = 16
+		return ..()
 
 /obj/item/stack/money/doubloon
 	name = "spanish doubloons"
@@ -76,15 +100,23 @@
 	icon_state = "goldcoin_pile"
 	amount = 1
 	value = 32
-/obj/item/stack/money/doubloon/dollar/New()
-	..()
-	if (map.ordinal_age == 0)
+/obj/item/stack/money/doubloon/New()
+	if (map.ordinal_age >= 4)   //Not being called
+		name = "50 Dollar Bills"
+		desc = "A/some dollar(s) of paper money."
+		singular_name = "50 Dollar Bill"
+		icon_state = "money"
+		amount = 1
+		value = 32
+		return ..()
+	else if (map.ordinal_age == 0)
 		name = "spanish doubloons"
 		desc = "A large gold coin, the largest in circulation. Worth 32 reales."
 		singular_name = "doubloon"
 		icon_state = "goldcoin_pile"
 		amount = 1
 		value = 32
+		return ..()
 
 /obj/item/stack/money/goldnugget
 	name = "gold nuggets"


### PR DESCRIPTION
Fixing Dollar initialization, bringing the Dollar back. Working, fully tested on localhost.
Dollar evaluation still based on the old Spanish currency, but for now it will be enough to not break muh immersion.

1 Dollar bill = 1 Spanish Coin
5 Dollar bill = 1 Spanish Dollar
20 Dollar bill = 1 Spanish Escudo
50 Dollar bill = 1 Spanish Doubloon

We will need to work at supplysystem aswell in order to fix the Dollar evaluation.
Comming soon™

(Previous one was closed to get an new one with an lazy fix in the 1 Dollar Bill value)