### PR TITLE
- Charcoal may now be put directly into barrels, just like coal.

### DIFF
--- a/code/game/objects/structures/factory/factory.dm
+++ b/code/game/objects/structures/factory/factory.dm
@@ -61,6 +61,10 @@
 				fuel += I.amount*3
 				qdel(I)
 				return
+			else if (istype(I, /obj/item/stack/ore/charcoal))
+				fuel += I.amount*1
+				qdel(I)
+				return
 			else if (istype(I, /obj/item/stack/ore/iron) || istype(I, /obj/item/stack/material/iron))
 				iron += I.amount
 				qdel(I)
@@ -242,7 +246,11 @@
 			else if (istype(I, /obj/item/stack/ore/coal))      //FUEL 3
 				fuel += I.amount*3
 				qdel(I)
-				return                  //INPUT 1                                   //OUTPUT1
+				return                  //INPUT 1
+			else if (istype(I, /obj/item/stack/ore/charcoal))      //FUEL 3
+				fuel += I.amount*1
+				qdel(I)
+				return                  //INPUT 1                                    //OUTPUT1
 			else if (istype(I, /obj/item/stack/money/goldcoin) || istype(I, /obj/item/stack/material/gold))
 				gold += I.amount
 				qdel(I)

--- a/code/game/objects/structures/kitchen/oven.dm
+++ b/code/game/objects/structures/kitchen/oven.dm
@@ -58,6 +58,10 @@
 		fuel += I.amount*3
 		qdel(I)
 		return
+	else if (istype(I, /obj/item/stack/ore/charcoal))
+		fuel += I.amount*1
+		qdel(I)
+		return
 	var/space = max_space
 	for (var/obj/item/II in contents)
 		space -= II.w_class
@@ -367,6 +371,10 @@
 				return
 			else if (istype(I, /obj/item/stack/ore/coal))
 				fuel += I.amount*3
+				qdel(I)
+				return
+			else if (istype(I, /obj/item/stack/ore/charcoal))
+				fuel += I.amount*1
 				qdel(I)
 				return
 			else if (istype(I, /obj/item/stack/ore/iron) || istype(I, /obj/item/stack/material/iron))

--- a/code/modules/1713/machinery/engines/heatsource.dm
+++ b/code/modules/1713/machinery/engines/heatsource.dm
@@ -37,6 +37,11 @@
 			user << "You refuel the [src]."
 			qdel(W)
 			return
+		else if (istype(W, /obj/item/stack/ore/charcoal))
+			fuel += (80)*W.amount
+			user << "You refuel the [src]."
+			qdel(W)
+			return
 		else if (istype(W, /obj/item/stack/material/wood))
 			fuel += (60)*W.amount
 			user << "You refuel the [src]."

--- a/code/modules/1713/siege/fire.dm
+++ b/code/modules/1713/siege/fire.dm
@@ -51,6 +51,11 @@
 			user << "You refuel the [src]."
 			qdel(W)
 			return
+		else if (istype(W, /obj/item/stack/ore/charcoal))
+			fuel += (80)*W.amount
+			user << "You refuel the [src]."
+			qdel(W)
+			return
 		else if (istype(W, /obj/item/stack/material/wood))
 			fuel += (60)*W.amount
 			user << "You refuel the [src]."

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -725,6 +725,13 @@
 			else
 				qdel(I)
 			return
+		else if (istype(I, /obj/item/stack/ore/charcoal))
+			reagents.add_reagent("carbon",3)
+			if (I.amount>1)
+				I.amount -= 1
+			else
+				qdel(I)
+			return
 	else
 		user << "The [src] is full!"
 	..()


### PR DESCRIPTION
    * Using this method produces carbon, so you cannot use it to cure toxin/rads
    * To get charcoal to treat toxins/rads, use an extraction kit.
- Charcoal can now be used as fuel in furnaces and light sources.