### PR TITLE
Sets default map back to nomads.dmm from nomads_new_world.dmm

### DIFF
--- a/civ13.dme
+++ b/civ13.dme
@@ -908,5 +908,5 @@
 #include "code\processes\zoom\zoom_scopes.dm"
 #include "interface\interface.dm"
 #include "interface\skin.dmf"
-#include "maps\special\nomads_new_world.dmm"
+#include "maps\special\nomads.dmm"
 // END_INCLUDE


### PR DESCRIPTION
You don't need a sociology degree paired with liberal arts for someone to tell you that the extra large map size is actually throttling the server because everyone is **super** spread out. Its not very approachable for new players and if they want it, they can vote for it and it'll work just as before as long as they are 20 ungas strong for the highpop new world.

* Sets the default map back to nomads.dm

* Maybe in the future we can make a dedicated low-pop 100x100 map when there are lower counts of players, i've already asked around.